### PR TITLE
campos para longitud y latitud en usuarios

### DIFF
--- a/src/main/java/com/natalia/relab/model/Usuario.java
+++ b/src/main/java/com/natalia/relab/model/Usuario.java
@@ -39,5 +39,9 @@ public class Usuario {
     @Column
     private boolean admin;
     @Column
-    private float saldo;
+    private Float saldo; // Cambio estos atributos a objetos envoltorio (de float y double a Float y Double para evitar los errores de campo vacío en la BBDD)
+    @Column
+    private Double latitud;
+    @Column
+    private Double longitud;
 }

--- a/src/main/java/com/natalia/relab/service/UsuarioService.java
+++ b/src/main/java/com/natalia/relab/service/UsuarioService.java
@@ -46,6 +46,9 @@ public class UsuarioService {
         usuarioAnterior.setFechaAlta(usuario.getFechaAlta());
         usuarioAnterior.setTipoUsuario(usuario.getTipoUsuario());
         usuarioAnterior.setAdmin(usuario.isAdmin());
+        usuarioAnterior.setSaldo(usuario.getSaldo());
+        usuarioAnterior.setLatitud(usuario.getLatitud());
+        usuarioAnterior.setLongitud(usuario.getLongitud());
 
         return usuarioRepository.save(usuarioAnterior);
 


### PR DESCRIPTION
Agrego los campos `latitud` y `longitud` en la entidad **Usuario**, con el objetivo de poder representar la ubicación de cada usuario en el mapa dentro de la futura app móvil que consumirá esta API.
Dado que los registros antiguos tenían los campos `saldo`, `latitud` y `longitud` en `NULL`, la operación **GET /usuarios** fallaba por la incompatibilidad con los tipos primitivos.
Para solucionarlo, he cambiado estos atributos a **objetos envoltorio** (`float` → `Float`, `double` → `Double`), permitiendo que los valores `NULL` se manejen correctamente y se devuelvan sin errores en las respuestas JSON.

 Finalmente, he actualizado el método `modificar` en `UsuarioService` para incluir el mapeo de los nuevos atributos.