### PR TITLE
Añade filtrado por nickname en GET /usuarios. refs #32

### DIFF
--- a/src/main/java/com/natalia/relab/controller/UsuarioController.java
+++ b/src/main/java/com/natalia/relab/controller/UsuarioController.java
@@ -22,10 +22,23 @@ public class UsuarioController {
     private UsuarioService usuarioService;
 
     @GetMapping("/usuarios")
-    public ResponseEntity<List<UsuarioOutDto>> listarTodos() {
-        List<UsuarioOutDto> todosUsuarios = usuarioService.listarTodos();
-        return ResponseEntity.ok(todosUsuarios);
+    public ResponseEntity<?> listarTodos(
+            @RequestParam(value = "nickname", required = false) String nickname)
+            throws UsuarioNoEncontradoException {
+
+        if (nickname != null && !nickname.isEmpty()) {
+            UsuarioOutDto usuario = usuarioService.buscarPorNickname(nickname);
+            if (usuario != null) {
+                return ResponseEntity.ok(usuario);
+            } else {
+                return ResponseEntity.notFound().build(); // Genera una respuesta HTTP 404
+            }
+        } else {
+            List<UsuarioOutDto> todosUsuarios = usuarioService.listarTodos();
+            return ResponseEntity.ok(todosUsuarios); // Devuelve un 200 OK con la respuesta del usuario
+        }
     }
+
 
     @GetMapping("/usuarios/{id}")
     public ResponseEntity<UsuarioOutDto> ListarPorId(@PathVariable long id) throws UsuarioNoEncontradoException {
@@ -35,8 +48,8 @@ public class UsuarioController {
 
     @PostMapping("/usuarios")
     public ResponseEntity<UsuarioOutDto> agregarUsuario(@RequestBody UsuarioInDto usuarioInDto) {
-       UsuarioOutDto nuevoUsuario = usuarioService.agregar(usuarioInDto);
-       return new ResponseEntity<>(nuevoUsuario, HttpStatus.CREATED);
+        UsuarioOutDto nuevoUsuario = usuarioService.agregar(usuarioInDto);
+        return new ResponseEntity<>(nuevoUsuario, HttpStatus.CREATED);
     }
 
     @PutMapping("/usuarios/{id}")
@@ -58,3 +71,5 @@ public class UsuarioController {
     }
 
 }
+
+

--- a/src/main/java/com/natalia/relab/repository/UsuarioRepository.java
+++ b/src/main/java/com/natalia/relab/repository/UsuarioRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UsuarioRepository extends CrudRepository<Usuario,Long> {
 
     List<Usuario> findAll();
+    Optional<Usuario> findByNickname(String nickname);
 }

--- a/src/main/java/com/natalia/relab/service/UsuarioService.java
+++ b/src/main/java/com/natalia/relab/service/UsuarioService.java
@@ -64,6 +64,13 @@ public class UsuarioService {
        return mapToOutDto(usuario);
     }
 
+    // --- GET con FILTRADO por nickname
+    public UsuarioOutDto buscarPorNickname(String nickname) throws UsuarioNoEncontradoException {
+        Usuario usuario = usuarioRepository.findByNickname(nickname)
+                .orElseThrow(UsuarioNoEncontradoException::new);
+        return mapToOutDto(usuario);
+    }
+
     // --- PUT / modificar
     public UsuarioOutDto modificar(long id, UsuarioUpdateDto usuarioUpdateDto) throws UsuarioNoEncontradoException {
         Usuario usuarioAnterior = usuarioRepository.findById(id) //Tal y como estaba en la BBDD


### PR DESCRIPTION
- Modifica la operación GET que devuelve todos los usuarios.
- Ahora, si se pasa un parámetro `nickname` en la query, solo se devuelven los usuarios cuyo nickname coincide.
- Ejemplo: `http://localhost:8080/usuarios?nickname=Maria22` devuelve únicamente el usuario con nickname `Maria22`.