### PR TITLE
Filtrado por nickname y password para login ReLab. refs #32

### DIFF
--- a/src/main/java/com/natalia/relab/controller/UsuarioController.java
+++ b/src/main/java/com/natalia/relab/controller/UsuarioController.java
@@ -23,20 +23,25 @@ public class UsuarioController {
 
     @GetMapping("/usuarios")
     public ResponseEntity<?> listarTodos(
-            @RequestParam(value = "nickname", required = false) String nickname)
+            @RequestParam(value = "nickname", required = false) String nickname,
+            @RequestParam(value = "password", required = false) String password)
             throws UsuarioNoEncontradoException {
 
+        // Login: nickname + password
+        if (nickname != null && !nickname.isEmpty() && password != null && !password.isEmpty()) {
+            UsuarioOutDto usuario = usuarioService.login(nickname, password);
+            return ResponseEntity.ok(usuario);
+        }
+
+        // Filtrado solo por nickname
         if (nickname != null && !nickname.isEmpty()) {
             UsuarioOutDto usuario = usuarioService.buscarPorNickname(nickname);
-            if (usuario != null) {
-                return ResponseEntity.ok(usuario);
-            } else {
-                return ResponseEntity.notFound().build(); // Genera una respuesta HTTP 404
-            }
-        } else {
-            List<UsuarioOutDto> todosUsuarios = usuarioService.listarTodos();
-            return ResponseEntity.ok(todosUsuarios); // Devuelve un 200 OK con la respuesta del usuario
+            return ResponseEntity.ok(usuario);
         }
+
+        // Todos los usuarios
+        List<UsuarioOutDto> todosUsuarios = usuarioService.listarTodos();
+        return ResponseEntity.ok(todosUsuarios);
     }
 
 

--- a/src/main/java/com/natalia/relab/repository/UsuarioRepository.java
+++ b/src/main/java/com/natalia/relab/repository/UsuarioRepository.java
@@ -12,4 +12,5 @@ public interface UsuarioRepository extends CrudRepository<Usuario,Long> {
 
     List<Usuario> findAll();
     Optional<Usuario> findByNickname(String nickname);
+    Optional<Usuario> findByNicknameAndPassword(String nickname, String password);
 }

--- a/src/main/java/com/natalia/relab/service/UsuarioService.java
+++ b/src/main/java/com/natalia/relab/service/UsuarioService.java
@@ -71,6 +71,13 @@ public class UsuarioService {
         return mapToOutDto(usuario);
     }
 
+    // --- GET con FILTRADO por nickname y password para LOGIN ReLab
+    public UsuarioOutDto login(String nickname, String password) throws UsuarioNoEncontradoException {
+        Usuario usuario = usuarioRepository.findByNicknameAndPassword(nickname, password)
+                .orElseThrow(UsuarioNoEncontradoException::new);
+        return mapToOutDto(usuario);
+    }
+
     // --- PUT / modificar
     public UsuarioOutDto modificar(long id, UsuarioUpdateDto usuarioUpdateDto) throws UsuarioNoEncontradoException {
         Usuario usuarioAnterior = usuarioRepository.findById(id) //Tal y como estaba en la BBDD


### PR DESCRIPTION
- Implementa filtrado en la operación de login para la aplicación móvil.
- Ahora solo se devuelve el usuario si coinciden `nickname` y `password`.
- Permite que la app móvil autentique usuarios correctamente mediante estos parámetros.
- Ejemplo de uso: `http://localhost:8080/usuarios?nickname=Fer94&password=secreto1234`