### PR TITLE
Filtro por tipoUsuario. refs #32

### DIFF
--- a/src/main/java/com/natalia/relab/controller/UsuarioController.java
+++ b/src/main/java/com/natalia/relab/controller/UsuarioController.java
@@ -24,7 +24,8 @@ public class UsuarioController {
     @GetMapping("/usuarios")
     public ResponseEntity<?> listarTodos(
             @RequestParam(value = "nickname", required = false) String nickname,
-            @RequestParam(value = "password", required = false) String password)
+            @RequestParam(value = "password", required = false) String password,
+            @RequestParam(value = "tipoUsuario", required = false) String tipoUsuario)
             throws UsuarioNoEncontradoException {
 
         // Login: nickname + password
@@ -37,6 +38,12 @@ public class UsuarioController {
         if (nickname != null && !nickname.isEmpty()) {
             UsuarioOutDto usuario = usuarioService.buscarPorNickname(nickname);
             return ResponseEntity.ok(usuario);
+        }
+
+        // Filtrado solo por tipoUsuario
+        if (tipoUsuario != null && !tipoUsuario.isEmpty()) {
+            List<UsuarioOutDto> usuarios = usuarioService.buscarPorTipoUsuario(tipoUsuario);
+            return ResponseEntity.ok(usuarios);
         }
 
         // Todos los usuarios

--- a/src/main/java/com/natalia/relab/repository/UsuarioRepository.java
+++ b/src/main/java/com/natalia/relab/repository/UsuarioRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 public interface UsuarioRepository extends CrudRepository<Usuario,Long> {
 
     List<Usuario> findAll();
-    Optional<Usuario> findByNickname(String nickname);
+    Optional<Usuario> findByNickname(String nickname); // Se pone Optional porque puede existir un usuario con ese nickname o ninguno
     Optional<Usuario> findByNicknameAndPassword(String nickname, String password);
+    List<Usuario> findByTipoUsuario(String tipoUsuario);
 }

--- a/src/main/java/com/natalia/relab/service/UsuarioService.java
+++ b/src/main/java/com/natalia/relab/service/UsuarioService.java
@@ -78,6 +78,14 @@ public class UsuarioService {
         return mapToOutDto(usuario);
     }
 
+    // --- GET con FILTRADO por tipo de Usuario
+    public List<UsuarioOutDto> buscarPorTipoUsuario(String tipoUsuario) {
+        return usuarioRepository.findByTipoUsuario(tipoUsuario)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
     // --- PUT / modificar
     public UsuarioOutDto modificar(long id, UsuarioUpdateDto usuarioUpdateDto) throws UsuarioNoEncontradoException {
         Usuario usuarioAnterior = usuarioRepository.findById(id) //Tal y como estaba en la BBDD


### PR DESCRIPTION
Ahora permite un filtrado por `tipoUsuario`, de esta forma puedo recuperar todos aquellos perfiles de Empresa, Particulares o de Centros de Investigación.

Ejemplo de consulta: `http://localhost:8080/usuarios?tipoUsuario=Empresa`  Comprobada en HOPPSCOTCH