### PR TITLE
filtros para clase categoria. refs #32

### DIFF
--- a/src/main/java/com/natalia/relab/dto/CategoriaInDto.java
+++ b/src/main/java/com/natalia/relab/dto/CategoriaInDto.java
@@ -14,6 +14,6 @@ public class CategoriaInDto {
     private String descripcion;
 //    @JsonFormat(pattern = "yyyy-MM-dd")
 //    private LocalDate fechaCreacion;
-    private boolean activo;
+    private boolean activa;
     private float tasaComision;
 }

--- a/src/main/java/com/natalia/relab/dto/CategoriaOutDto.java
+++ b/src/main/java/com/natalia/relab/dto/CategoriaOutDto.java
@@ -16,6 +16,6 @@ public class CategoriaOutDto {
     private String descripcion;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate fechaCreacion;
-    private boolean activo;
+    private boolean activa;
     private float tasaComision;
 }

--- a/src/main/java/com/natalia/relab/dto/CategoriaUpdateDto.java
+++ b/src/main/java/com/natalia/relab/dto/CategoriaUpdateDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 public class CategoriaUpdateDto {
     private String nombre;
     private String descripcion;
-    private boolean activo;
+    private boolean activa;
     private float tasaComision;
 }

--- a/src/main/java/com/natalia/relab/model/Categoria.java
+++ b/src/main/java/com/natalia/relab/model/Categoria.java
@@ -26,7 +26,7 @@ public class Categoria {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate fechaCreacion;
     @Column
-    private boolean activo;
+    private boolean activa;
     @Column(name = "tasa_comision")
     private float tasaComision; // Habrá que validar que esté entre 0 y 1
 

--- a/src/main/java/com/natalia/relab/repository/CategoriaRepository.java
+++ b/src/main/java/com/natalia/relab/repository/CategoriaRepository.java
@@ -5,9 +5,15 @@ import com.natalia.relab.model.Producto;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CategoriaRepository  extends CrudRepository<Categoria,Long> {
     List<Categoria> findAll();
+    Optional<Categoria> findByNombre(String nombre);
+    List<Categoria> findByActiva(boolean activa);
+    List<Categoria> findByFechaCreacion(LocalDate fechaCreacion); // Permite filtrar por una fecha exacta
+    List<Categoria> findByFechaCreacionBetween(LocalDate desde, LocalDate hasta); // Permite filtrar por rango de fecha
 }

--- a/src/main/java/com/natalia/relab/service/CategoriaService.java
+++ b/src/main/java/com/natalia/relab/service/CategoriaService.java
@@ -26,7 +26,7 @@ public class CategoriaService {
 
         categoria.setFechaCreacion(LocalDate.now());
 
-        categoria.setActivo(categoriaInDto.isActivo());
+        categoria.setActiva(categoriaInDto.isActiva());
         categoria.setTasaComision(categoriaInDto.getTasaComision());
 
         Categoria guardada  = categoriaRepository.save(categoria);
@@ -49,6 +49,36 @@ public class CategoriaService {
         return mapToOutDto(categoria);
     }
 
+    // --- GET con FILTRADO por nombre
+    public CategoriaOutDto buscarPorNombre(String nombre) throws CategoriaNoEncontradaException {
+        Categoria categoria = categoriaRepository.findByNombre(nombre)
+                .orElseThrow(CategoriaNoEncontradaException::new);
+        return mapToOutDto(categoria);
+    }
+
+    // --- GET con FILTRADO según si la categoría está activa o no
+    public List<CategoriaOutDto> buscarActivos(boolean activa) {
+        return categoriaRepository.findByActiva(activa)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
+    // -- GET con FILTRADO por fecha de creación EXACTA o RANGO
+    public List<CategoriaOutDto> buscarPorFecha(LocalDate fechaCreacion, LocalDate desde, LocalDate hasta) {
+        List<Categoria> lista;
+        if (fechaCreacion != null) {
+            lista = categoriaRepository.findByFechaCreacion(fechaCreacion);
+        } else if (desde != null && hasta != null) {
+            lista = categoriaRepository.findByFechaCreacionBetween(desde, hasta);
+        } else if (desde != null){
+            lista = categoriaRepository.findByFechaCreacionBetween(desde, LocalDate.now());
+        } else {
+            return listarTodas(); // Si no me dan parámetros de fecha listo todas las categorias.
+        }
+        return lista.stream().map(this::mapToOutDto).toList();
+    }
+
     // --- PUT / modificar
     public CategoriaOutDto modificar(long id, CategoriaUpdateDto categoriaUpdateDto) throws CategoriaNoEncontradaException {
         Categoria categoriaAnterior = categoriaRepository.findById(id)
@@ -56,7 +86,7 @@ public class CategoriaService {
 
         categoriaAnterior.setNombre(categoriaUpdateDto.getNombre());
         categoriaAnterior.setDescripcion(categoriaUpdateDto.getDescripcion());
-        categoriaAnterior.setActivo(categoriaUpdateDto.isActivo());
+        categoriaAnterior.setActiva(categoriaUpdateDto.isActiva());
         categoriaAnterior.setTasaComision(categoriaUpdateDto.getTasaComision());
 
         Categoria actualizada = categoriaRepository.save(categoriaAnterior);
@@ -79,7 +109,7 @@ public class CategoriaService {
                 categoria.getNombre(),
                 categoria.getDescripcion(),
                 categoria.getFechaCreacion(),
-                categoria.isActivo(),
+                categoria.isActiva(),
                 categoria.getTasaComision()
         );
 


### PR DESCRIPTION
### ✅ Filtros añadidos para Categorías

Se implementaron filtros en el endpoint `/categorias` para mejorar la búsqueda de resultados:

| Filtro | Parámetro | Descripción | Ejemplo |
|--------|-----------|------------|--------|
| Nombre | `nombre` | Busca una categoría por su nombre exacto | `GET /categorias?nombre=Biotecnología` |
| Activa | `activa` | Filtra categorías activas o inactivas | `GET /categorias?activa=true` |
| Fecha exacta | `fechaCreacion` | Busca categorías creadas en una fecha específica | `GET /categorias?fechaCreacion=2025-01-15` |
| Rango de fechas | `desde`, `hasta` | Busca categorías dentro de un rango de fechas | `GET /categorias?desde=2025-01-01&hasta=2025-02-01` |

### 🛠️ Ejemplos de uso


```http
GET /categorias?nombre=Centrífugas
```
```http
GET /categorias?activa=true
```
```http
GET /categorias?fechaCreacion=2025-10-24
```
```http
GET /categorias?desde=2025-10-24&hasta=2025-11-05
```
```http
GET /categorias?desde=2025-10-24
```

