### PR TITLE
filtros para entidad producto. refs #32

### DIFF
--- a/src/main/java/com/natalia/relab/controller/CategoriaController.java
+++ b/src/main/java/com/natalia/relab/controller/CategoriaController.java
@@ -44,7 +44,7 @@ public class CategoriaController {
 
             // Filtrado por activo
             if (activa!= null) {
-                List<CategoriaOutDto> categorias = categoriaService.buscarActivos(activa);
+                List<CategoriaOutDto> categorias = categoriaService.buscarActivas(activa);
                 return ResponseEntity.ok(categorias);
             }
 

--- a/src/main/java/com/natalia/relab/repository/ProductoRepository.java
+++ b/src/main/java/com/natalia/relab/repository/ProductoRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProductoRepository extends CrudRepository<Producto,Long> {
     List<Producto> findAll(); // Es de los metodos de la interfaz CrudRepository
+    List<Producto> findByNombreContainingIgnoreCase(String nombre); // Para filtrar por coincidencia parcial del nombre sin tener en cuenta mayúsculas o minúsculas
+    List<Producto> findByActivo(boolean activo);
+    List<Producto> findByCategoriaId(Long categoriaId);
 }

--- a/src/main/java/com/natalia/relab/service/CategoriaService.java
+++ b/src/main/java/com/natalia/relab/service/CategoriaService.java
@@ -57,7 +57,7 @@ public class CategoriaService {
     }
 
     // --- GET con FILTRADO según si la categoría está activa o no
-    public List<CategoriaOutDto> buscarActivos(boolean activa) {
+    public List<CategoriaOutDto> buscarActivas(boolean activa) {
         return categoriaRepository.findByActiva(activa)
                 .stream()
                 .map(this::mapToOutDto)

--- a/src/main/java/com/natalia/relab/service/ProductoService.java
+++ b/src/main/java/com/natalia/relab/service/ProductoService.java
@@ -72,6 +72,29 @@ public class ProductoService {
         return mapToOutDto(producto);
     }
 
+    // --- GET con FILTRADO por nombre (coincidencias parciales y sin tener en cuenta mayúsculas y minúsculas)
+    public List<ProductoOutDto> buscarPorNombreParcial(String nombre) {
+        return productoRepository.findByNombreContainingIgnoreCase(nombre)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
+    // --- GET con FILTRADO según si el producto está activo o no
+    public List<ProductoOutDto> buscarActivos (boolean activo) {
+        return productoRepository.findByActivo(activo)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
+    // --- GET con FILTRADO según la categoría a la que pertenezca el producto (filtrado por id de la categoría)
+    public List<ProductoOutDto> buscarPorCategoriaId(Long categoriaId) {
+        return productoRepository.findByCategoriaId(categoriaId)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
 
     // --- PUT / modificar
     public ProductoOutDto modificar(long id, ProductoUpdateDto productoUpdateDto) throws ProductoNoEncontradoException, CategoriaNoEncontradaException {


### PR DESCRIPTION
## 🧪 Filtros implementados en `/productos`

He añadido tres filtros en el endpoint `GET /productos`.

### ✅ Filtros disponibles

| Criterio | Parámetro | Tipo | Descripción |
|-----------|------------|------|--------------|
| Nombre (búsqueda parcial) | `nombre` | `String` | Filtra productos cuyo nombre **contenga** el texto indicado (no distingue mayúsculas/minúsculas). |
| Categoría | `categoriaId` | `Long` | Filtra los productos que pertenecen a una **categoría específica** (usando su ID como FK). |
| Activo | `activo`  | `boolean` | Filtra productos según si están activos o no. |

> 🧠 Si no se envían parámetros, se listan **todos los productos**.  
> Si la categoría no existe, se lanza `CategoriaNoEncontradaException`.  
> Si existe pero no hay productos asociados, se devuelve `200 OK` con una lista vacía `[]`.

---

### 📌 Ejemplos de endpoints
#### 🔹 Filtrar por nombre (coincidencia parcial)
```http
GET http://localhost:8080/productos?nombre=agitador
```
#### 🔹 Filtrar por categoría (usando el ID de la categoría)
```http
GET http://localhost:8080/productos?categoriaId=3
```
#### 🔹 Filtrar por estado (activo/inactivo)
```http
GET http://localhost:8080/productos?activo=true
```
