### PR TITLE
filtros para alquiler. refs #32

### DIFF
--- a/src/main/java/com/natalia/relab/controller/AlquilerController.java
+++ b/src/main/java/com/natalia/relab/controller/AlquilerController.java
@@ -2,6 +2,8 @@ package com.natalia.relab.controller;
 
 import com.natalia.relab.dto.*;
 import com.natalia.relab.service.AlquilerService;
+import com.natalia.relab.service.ProductoService;
+import com.natalia.relab.service.UsuarioService;
 import exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -15,9 +17,43 @@ public class AlquilerController {
 
     @Autowired
     private AlquilerService alquilerService;
+    @Autowired
+    private UsuarioService usuarioService;
+    @Autowired
+    private ProductoService productoService;
 
     @GetMapping("/alquileres")
-    public ResponseEntity<List<AlquilerOutDto>> verTodos(){
+    public ResponseEntity<List<AlquilerOutDto>> verTodos(
+            @RequestParam(value="arrendadorId", required = false) Long arrendadorId,
+            @RequestParam(value="arrendatarioId", required = false) Long arrendatarioId,
+            @RequestParam(value="productoId", required = false) Long productoId)
+            throws UsuarioNoEncontradoException, ProductoNoEncontradoException {
+
+        if (arrendadorId !=null){
+            // Se verifica que el usuario arrendador exista
+            usuarioService.buscarPorId(arrendadorId);
+
+            List<AlquilerOutDto> alquileres = alquilerService.buscarPorArrendadorId(arrendadorId);
+            return ResponseEntity.ok(alquileres);
+        }
+
+        if (arrendatarioId !=null){
+            // Se verifica que el usuario arrendatario exista
+            usuarioService.buscarPorId(arrendatarioId);
+
+            List<AlquilerOutDto> alquileres = alquilerService.buscarPorArrendatarioId(arrendatarioId);
+            return ResponseEntity.ok(alquileres);
+        }
+
+        if (productoId !=null){
+            // Se verifica que el producto exista
+            productoService.buscarPorId(productoId);
+
+            List<AlquilerOutDto> alquileres = alquilerService.buscarPorProductoId(productoId);
+            return ResponseEntity.ok(alquileres);
+        }
+
+
         List<AlquilerOutDto> todosAlquileres = alquilerService.listarTodos();
         return ResponseEntity.ok(todosAlquileres);
     }
@@ -55,6 +91,18 @@ public class AlquilerController {
     @ExceptionHandler(AlquilerNoEncontradoException.class)
     public ResponseEntity<ErrorResponse> handleExcpetion(AlquilerNoEncontradoException ex) {
         ErrorResponse errorResponse = new ErrorResponse(404, "no-encontrado", "El registro de alquiler no existe");
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(UsuarioNoEncontradoException.class)
+    public ResponseEntity<ErrorResponse> handleExcpetion(UsuarioNoEncontradoException uex) {
+        ErrorResponse errorResponse = new ErrorResponse(404, "no-encontrado", "El usuario no existe");
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ProductoNoEncontradoException.class)
+    public ResponseEntity<ErrorResponse> handleExcpetion(ProductoNoEncontradoException pex) {
+        ErrorResponse errorResponse = new ErrorResponse(404, "no-encontrado", "El producto no existe");
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/natalia/relab/repository/AlquilerRepository.java
+++ b/src/main/java/com/natalia/relab/repository/AlquilerRepository.java
@@ -9,4 +9,7 @@ import java.util.List;
 @Repository
 public interface AlquilerRepository extends CrudRepository<Alquiler, Long> {
     List<Alquiler> findAll();
+    List<Alquiler> findByArrendadorId(Long id);
+    List<Alquiler> findByArrendatarioId(Long id);
+    List<Alquiler> findByProductoId(Long id);
 }

--- a/src/main/java/com/natalia/relab/service/AlquilerService.java
+++ b/src/main/java/com/natalia/relab/service/AlquilerService.java
@@ -73,6 +73,31 @@ public class AlquilerService {
         return mapToOutDto(alquiler);
     }
 
+    // --- GET con FILTRADO por ArrendadorId
+    public List<AlquilerOutDto> buscarPorArrendadorId(Long arrendadorId) {
+        return alquilerRepository.findByArrendadorId(arrendadorId)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
+    // --- GET con FILTRADO por ArrendatarioId
+    public List<AlquilerOutDto> buscarPorArrendatarioId(Long arrendatarioId) {
+        return alquilerRepository.findByArrendatarioId(arrendatarioId)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
+    // --- GET con FILTRADO por ProductoId
+    public List<AlquilerOutDto> buscarPorProductoId(Long productoId) {
+        return alquilerRepository.findByProductoId(productoId)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
+    }
+
+
     // --- PUT / modificar
     public AlquilerOutDto modificar(long id, AlquilerUpdateDto alquilerUpdateDto) throws AlquilerNoEncontradoException {
         Alquiler alquilerAnterior = alquilerRepository.findById(id)


### PR DESCRIPTION
## 🧪 Filtros implementados en `/alquileres`

He añadido 3 filtros en el endpoint `GET /alquileres`.

### ✅ Filtros disponibles

| Criterio | Parámetro | Tipo | Descripción |
|-----------|------------|------|--------------|
| Arrendador | `arrendadorId` | `Long` | Filtra por arrendador, que es un usuario que tenga un determinado Id |
| Arrendatario | `arrendatarioId` | `Long` | Filtra por arrendatario, que es un usuario que tenga un determinado Id  |
| Producto | `productoId` | `Long` | Filtra por producto con un determinado Id.  Obtenemos los alquileres de ese producto  |


> 🧠 Si no se envían parámetros, se listan **todos los alquileres**.  
> Si el id del usuario (tanto arrendador como arrendatario) no existe, se lanza `UsuarioNoEncontradaException`.  
> Si el id del producto no existe, se lanza `UsuarioNoEncontradaException`. 
> Si existen pero no hay compraventas asociadas, se devuelve `200 OK` con una lista vacía `[]`.

---

### 📌 Ejemplos de endpoints  **GET**

#### 🔹 Filtrar por ID del arrendador
```http
GET http://localhost:8080/alquileres?arrendadorId=6
```
#### 🔹 Filtrar por ID del arrendatario
```http
GET http://localhost:8080/alquileres?arrendatarioId=4
```
#### 🔹 Filtrar por ID del producto
```http
GET http://localhost:8080/alquileres?productoId=10
```