### PR TITLE
Arreglo filtrado compraventas y categorias.  Closes #32

### DIFF
--- a/src/main/java/com/natalia/relab/controller/CategoriaController.java
+++ b/src/main/java/com/natalia/relab/controller/CategoriaController.java
@@ -36,10 +36,10 @@ public class CategoriaController {
             @RequestParam(value = "hasta", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hasta)
             throws CategoriaNoEncontradaException {
 
-            // Filtrado por nombre
+            // Filtrado por nombre --> Coincidencias parciales y sin distinguir mayúsculas y minúsculas
             if (nombre != null && !nombre.isEmpty()) {
-                CategoriaOutDto categoria = categoriaService.buscarPorNombre(nombre);
-                return ResponseEntity.ok(categoria);
+                List<CategoriaOutDto> categorias = categoriaService.buscarPorNombreParcial(nombre);
+                return ResponseEntity.ok(categorias);
             }
 
             // Filtrado por activo

--- a/src/main/java/com/natalia/relab/controller/CompraventaController.java
+++ b/src/main/java/com/natalia/relab/controller/CompraventaController.java
@@ -28,11 +28,11 @@ public class CompraventaController {
     private ProductoService productoService;
 
     @GetMapping("/compraventas")
-    public ResponseEntity<List<CompraventaOutDto>> verTodas(
+    public ResponseEntity<?> verTodas(
             @RequestParam(value="compradorId", required = false) Long compradorId,
             @RequestParam(value="vendedorId", required = false) Long vendedorId,
             @RequestParam(value="productoId", required = false) Long productoId)
-        throws UsuarioNoEncontradoException, ProductoNoEncontradoException {
+        throws UsuarioNoEncontradoException, ProductoNoEncontradoException, CompraventaNoEncontradaException {
 
         if (compradorId !=null){
             // Se verifica que el usuario comprador exista
@@ -54,8 +54,8 @@ public class CompraventaController {
             // Se verifica que el producto exista
             productoService.buscarPorId(productoId);
 
-            List<CompraventaOutDto> compraventas = compraventaService.buscarPorProductoId(productoId);
-            return ResponseEntity.ok(compraventas);
+            CompraventaOutDto compraventa = compraventaService.buscarPorProductoId(productoId);
+            return ResponseEntity.ok(compraventa);
         }
 
         List<CompraventaOutDto> todasCompraventas = compraventaService.listarTodas();

--- a/src/main/java/com/natalia/relab/repository/CategoriaRepository.java
+++ b/src/main/java/com/natalia/relab/repository/CategoriaRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Repository
 public interface CategoriaRepository  extends CrudRepository<Categoria,Long> {
     List<Categoria> findAll();
-    Optional<Categoria> findByNombre(String nombre);
+    Optional<Categoria> findByNombreContainingIgnoreCase(String nombre); // Para filtrar por coincidencia parcial del nombre sin tener en cuenta mayúsculas o minúsculas
     List<Categoria> findByActiva(boolean activa);
     List<Categoria> findByFechaCreacion(LocalDate fechaCreacion); // Permite filtrar por una fecha exacta
     List<Categoria> findByFechaCreacionBetween(LocalDate desde, LocalDate hasta); // Permite filtrar por rango de fecha

--- a/src/main/java/com/natalia/relab/repository/CompraventaRepository.java
+++ b/src/main/java/com/natalia/relab/repository/CompraventaRepository.java
@@ -5,11 +5,12 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CompraventaRepository extends CrudRepository<Compraventa, Long> {
     List<Compraventa> findAll();
     List<Compraventa> findByCompradorId(Long id);
     List<Compraventa> findByVendedorId(Long id);
-    List<Compraventa> findByProductoId(Long id);
+    Optional<Compraventa> findByProductoId(Long id); // Un mismo producto solo puede estar implicado en una transacción de compraventa
 }

--- a/src/main/java/com/natalia/relab/service/CategoriaService.java
+++ b/src/main/java/com/natalia/relab/service/CategoriaService.java
@@ -50,10 +50,11 @@ public class CategoriaService {
     }
 
     // --- GET con FILTRADO por nombre
-    public CategoriaOutDto buscarPorNombre(String nombre) throws CategoriaNoEncontradaException {
-        Categoria categoria = categoriaRepository.findByNombre(nombre)
-                .orElseThrow(CategoriaNoEncontradaException::new);
-        return mapToOutDto(categoria);
+    public List<CategoriaOutDto> buscarPorNombreParcial(String nombre)  {
+        return categoriaRepository.findByNombreContainingIgnoreCase(nombre)
+                .stream()
+                .map(this::mapToOutDto)
+                .toList();
     }
 
     // --- GET con FILTRADO según si la categoría está activa o no

--- a/src/main/java/com/natalia/relab/service/CompraventaService.java
+++ b/src/main/java/com/natalia/relab/service/CompraventaService.java
@@ -88,12 +88,11 @@ public class CompraventaService {
                 .toList();
     }
 
-    // --- GET con FILTRADO por ProductoId
-    public List<CompraventaOutDto> buscarPorProductoId(Long productoId) {
-        return compraventaRepository.findByProductoId(productoId)
-                .stream()
-                .map(this::mapToOutDto)
-                .toList();
+    // --- GET con FILTRADO por ProductoId --> Solo una compraventa por producto
+    public CompraventaOutDto buscarPorProductoId(Long productoId) throws CompraventaNoEncontradaException {
+        Compraventa compraventa = compraventaRepository.findByProductoId(productoId)
+                .orElseThrow(CompraventaNoEncontradaException::new);
+        return mapToOutDto(compraventa);
     }
 
     // --- PUT / modificar


### PR DESCRIPTION
- Como un producto solamente puede comprarse o venderse una vez, arreglo que al buscar por productoId en compraventas se devuelva un listado de productos.  Tendrá que devolverse un registro o ninguno.
- Permito búsquedas por coincidencia parcial y sin tener en cuenta mayúsculas o minúsculas al buscar por nombre de categoría.

*Todo ha sido probado en HOPPSCOTCH*