### PR TITLE
nuevo campo modo para producto. refs #60

### DIFF
--- a/src/main/java/com/natalia/relab/dto/ProductoInDto.java
+++ b/src/main/java/com/natalia/relab/dto/ProductoInDto.java
@@ -21,6 +21,7 @@ public class ProductoInDto { // Es un objeto que utilizaré para mandar informac
 //    @JsonFormat(pattern = "yyyy-MM-dd")
 //    private LocalDate fechaActualizacion;
     private boolean activo;
+    private boolean modo;
     private long categoriaId;
     @NotNull(message = "Debe especificarse el usuario que publica el producto")
     private Long usuarioId;

--- a/src/main/java/com/natalia/relab/dto/ProductoOutDto.java
+++ b/src/main/java/com/natalia/relab/dto/ProductoOutDto.java
@@ -19,6 +19,7 @@ public class ProductoOutDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate fechaActualizacion;
     private boolean activo;
+    private boolean modo;
     private CategoriaSimpleDto categoria;
     private UsuarioSimpleDto usuario;
 }

--- a/src/main/java/com/natalia/relab/dto/ProductoUpdateDto.java
+++ b/src/main/java/com/natalia/relab/dto/ProductoUpdateDto.java
@@ -19,6 +19,7 @@ public class ProductoUpdateDto {
     private float precio;
 //    private LocalDate fechaActualizacion;
     private boolean activo;
+    private boolean modo;
     private long categoriaId;
 }
 

--- a/src/main/java/com/natalia/relab/model/Producto.java
+++ b/src/main/java/com/natalia/relab/model/Producto.java
@@ -29,6 +29,8 @@ public class Producto {
     private LocalDate fechaActualizacion;
     @Column
     private boolean activo;
+    @Column
+    private boolean modo; // Para saber si el producto se vende o se alquila
 
     // RELACIÓN CON TABLA CATEGORIA
     @ManyToOne // Cada producto tiene una sola categoría asociada, mientras que cada categoría puede aplicarse a varios productos.  Muchos productos se relacionan con una categoría.

--- a/src/main/java/com/natalia/relab/service/ProductoService.java
+++ b/src/main/java/com/natalia/relab/service/ProductoService.java
@@ -48,6 +48,7 @@ public class ProductoService {
             producto.setFechaActualizacion(LocalDate.now());
 
             producto.setActivo(productoInDto.isActivo());
+            producto.setModo(productoInDto.isModo());
             producto.setCategoria(categoria);
             producto.setUsuario(usuario);
 
@@ -118,6 +119,7 @@ public class ProductoService {
         productoAnterior.setPrecio(productoUpdateDto.getPrecio());
         productoAnterior.setFechaActualizacion(LocalDate.now()); // La cojo cada vez que se realizan modificaciones sobre el producto
         productoAnterior.setActivo(productoUpdateDto.isActivo());
+        productoAnterior.setModo(productoUpdateDto.isModo());
         productoAnterior.setCategoria(categoria);
         // El campo UsuarioId no quiero que se pueda modificar
 
@@ -158,6 +160,7 @@ public class ProductoService {
                 producto.getPrecio(),
                 producto.getFechaActualizacion(),
                 producto.isActivo(),
+                producto.isModo(),
                 categoriaSimple,
                 usuarioSimple
         );


### PR DESCRIPTION
Ahora es posible especificar si el producto está en venta o para alquiler.  He añadido el `boolean modo`.

He probado que el CRUD completo de Producto seguía funcionando en HOPPSCOTCH.  Además en DBeaver veo que ya existe esa nueva columna modo.