### PR TITLE
Cargar imágenes producto refs #60

### DIFF
--- a/src/main/java/com/natalia/relab/controller/ProductoController.java
+++ b/src/main/java/com/natalia/relab/controller/ProductoController.java
@@ -3,6 +3,7 @@ package com.natalia.relab.controller;
 import com.natalia.relab.dto.ProductoInDto;
 import com.natalia.relab.dto.ProductoOutDto;
 import com.natalia.relab.dto.ProductoUpdateDto;
+import com.natalia.relab.model.Producto;
 import com.natalia.relab.service.CategoriaService;
 import com.natalia.relab.service.ProductoService;
 import com.natalia.relab.service.UsuarioService;
@@ -12,6 +13,7 @@ import exception.UsuarioNoEncontradoException;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -79,6 +81,7 @@ public class ProductoController {
         return ResponseEntity.ok(dto);
     }
 
+
     @PostMapping("/productos")
     public ResponseEntity<ProductoOutDto> agregarProductos(@Valid @RequestBody ProductoInDto productoInDto)
             throws CategoriaNoEncontradaException, UsuarioNoEncontradoException {
@@ -99,5 +102,26 @@ public class ProductoController {
         return ResponseEntity.noContent().build();
     }
 
+    //  Endpoint específico para servir la imagen como archivo binario:
+    @GetMapping("/productos/{id}/imagen")
+    public ResponseEntity<byte[]> obtenerImagen(@PathVariable Long id) {
+        try {
+            Producto producto = productoService.buscarPorIdEntidad(id);
+
+            if (producto.getImagen() == null) {
+                return ResponseEntity.notFound().build();
+            }
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.IMAGE_JPEG)
+                    .body(producto.getImagen());
+
+        } catch (ProductoNoEncontradoException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+
 // --- Me llevo excepciones a GlobalExceptionHandler
+
 }

--- a/src/main/java/com/natalia/relab/dto/ProductoOutDto.java
+++ b/src/main/java/com/natalia/relab/dto/ProductoOutDto.java
@@ -22,4 +22,8 @@ public class ProductoOutDto {
     private boolean modo;
     private CategoriaSimpleDto categoria;
     private UsuarioSimpleDto usuario;
+
+    // Atributo para cargar la imagen. La app Android cargará la imagen incovando http así: http://localhost:8080/productos/1/imagen
+    private String imagenUrl; // ProductoOutDto relamente NO tiene la imagen.  Solo tiene una URL.
+
 }

--- a/src/main/java/com/natalia/relab/model/Producto.java
+++ b/src/main/java/com/natalia/relab/model/Producto.java
@@ -32,6 +32,11 @@ public class Producto {
     @Column
     private boolean modo; // Para saber si el producto se vende o se alquila
 
+    // Campo para almacenar la imagen en la BBDD
+    @Lob
+    @Column(columnDefinition = "MEDIUMBLOB")
+    private byte[] imagen;
+
     // RELACIÓN CON TABLA CATEGORIA
     @ManyToOne // Cada producto tiene una sola categoría asociada, mientras que cada categoría puede aplicarse a varios productos.  Muchos productos se relacionan con una categoría.
     @JoinColumn(name = "categoria_id") // FK

--- a/src/main/java/com/natalia/relab/service/ProductoService.java
+++ b/src/main/java/com/natalia/relab/service/ProductoService.java
@@ -134,6 +134,11 @@ public class ProductoService {
         productoRepository.delete(producto);
     }
 
+    // --- Metodo para devolver entidad completa del producto (incluyendo la imagen=
+    public Producto buscarPorIdEntidad(Long id) throws ProductoNoEncontradoException {
+        return productoRepository.findById(id)
+                .orElseThrow(ProductoNoEncontradoException::new);
+    }
 
     // --- Metodo auxiliar privado para mapear y no repetir código
     private ProductoOutDto mapToOutDto(Producto producto) {
@@ -162,7 +167,8 @@ public class ProductoService {
                 producto.isActivo(),
                 producto.isModo(),
                 categoriaSimple,
-                usuarioSimple
+                usuarioSimple,
+                "/productos/"  + producto.getId() + "/imagen"
         );
 
     }


### PR DESCRIPTION
Añadido soporte para almacenar y servir imágenes de productos

Este PR implementa la capacidad de **almacenar imágenes en la base de datos** y **exponer un endpoint para recuperarlas**, permitiendo que aplicaciones cliente obtengan la imagen de un producto mediante una URL dedicada.

##  Cambios principales

###  1. Modificación de la entidad `Producto`

Se añade un campo para almacenar la imagen como binario dentro de la BBDD:

```java
@Lob
@Column(columnDefinition = "MEDIUMBLOB")
private byte[] imagen;
```

---

###  2. Actualización del DTO `ProductoOutDto`

Se incorpora un nuevo atributo:

```java
private String imagenUrl;
```

Este campo expone la URL desde la que se puede obtener la imagen del producto, manteniendo ligero el DTO (no se envían bytes en cada consulta).

---

###  3. Ajustes en `ProductoService`

* Se añade el método:

```java
public Producto buscarPorIdEntidad(Long id)
```

para recuperar la entidad completa, incluyendo la imagen.

* El método `mapToOutDto()` ahora genera dinámicamente la URL pública:

```
/productos/{id}/imagen
```

---

###  4. Nuevo endpoint en `ProductoController`

Se crea un endpoint dedicado para devolver la imagen del producto:

```http
GET /productos/{id}/imagen
```

---

##  Resultado

* Se añade almacenamiento de imágenes en la base de datos.
* Los productos exponen su imagen mediante una URL limpia.
* El DTO se mantiene ligero y eficiente.
* Las aplicaciones cliente pueden obtener la imagen de forma independiente.
