### PR TITLE
mejora manejo de excepciones imagen producto. refs #60

### DIFF
--- a/src/main/java/com/natalia/relab/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/natalia/relab/controller/GlobalExceptionHandler.java
@@ -46,7 +46,8 @@ public class GlobalExceptionHandler {
             ProductoNoEncontradoException.class,
             AlquilerNoEncontradoException.class,
             CompraventaNoEncontradaException.class,
-            CategoriaNoEncontradaException.class
+            CategoriaNoEncontradaException.class,
+            ImagenNoEncontradaException.class
     })
 
     public ResponseEntity<ErrorResponse> handleNotFound(Exception ex) {
@@ -56,7 +57,8 @@ public class GlobalExceptionHandler {
             case "AlquilerNoEncontradoException" -> "El alquiler no existe";
             case "CompraventaNoEncontradaException" -> "La compraventa no existe";
             case "CategoriaNoEncontradaException" -> "La categoria no existe";
-            default -> "El recurso no fue encontrado";
+            case "ImagenNoEncontradaException" -> "El producto no tiene imagen";
+            default -> "El recurso no fue encontrado"; // Este default me obliga JAVA a ponerlo.
         };
 
         ErrorResponse errorResponse = ErrorResponse.notFound(message);

--- a/src/main/java/com/natalia/relab/controller/ProductoController.java
+++ b/src/main/java/com/natalia/relab/controller/ProductoController.java
@@ -8,6 +8,7 @@ import com.natalia.relab.service.CategoriaService;
 import com.natalia.relab.service.ProductoService;
 import com.natalia.relab.service.UsuarioService;
 import exception.CategoriaNoEncontradaException;
+import exception.ImagenNoEncontradaException;
 import exception.ProductoNoEncontradoException;
 import exception.UsuarioNoEncontradoException;
 import jakarta.validation.Valid;
@@ -104,24 +105,18 @@ public class ProductoController {
 
     //  Endpoint específico para servir la imagen como archivo binario:
     @GetMapping("/productos/{id}/imagen")
-    public ResponseEntity<byte[]> obtenerImagen(@PathVariable Long id) {
-        try {
+    public ResponseEntity<byte[]> obtenerImagen(@PathVariable Long id) throws ProductoNoEncontradoException, ImagenNoEncontradaException {
             Producto producto = productoService.buscarPorIdEntidad(id);
 
             if (producto.getImagen() == null) {
-                return ResponseEntity.notFound().build();
+                throw new ImagenNoEncontradaException();
             }
 
             return ResponseEntity.ok()
                     .contentType(MediaType.IMAGE_JPEG)
                     .body(producto.getImagen());
-
-        } catch (ProductoNoEncontradoException e) {
-            return ResponseEntity.notFound().build();
-        }
     }
 
-
-// --- Me llevo excepciones a GlobalExceptionHandler
+    // --- Me llevo excepciones a GlobalExceptionHandler
 
 }

--- a/src/main/java/exception/ImagenNoEncontradaException.java
+++ b/src/main/java/exception/ImagenNoEncontradaException.java
@@ -1,0 +1,6 @@
+package exception;
+
+public class ImagenNoEncontradaException extends Exception {
+
+}
+


### PR DESCRIPTION
# Mejora del control de excepciones para imágenes de productos

Se amplía el manejo de excepciones en el endpoint `/productos/{id}/imagen`:

- Si el producto **no existe**, se lanza `ProductoNoEncontradoException` → 404 con `"El producto no existe"`.
- Si el producto existe pero **no tiene imagen**, se lanza `ImagenNoEncontradaException` → 404 con `"El producto no tiene imagen"`.

Esto permite distinguir claramente ambos casos, manteniendo el resto del `GlobalExceptionHandler` y las respuestas personalizadas existentes.
