### PR TITLE
Integración de autenticación JWT y refactor de seguridad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,32 @@
             <artifactId>modelmapper</artifactId>
             <version>3.1.1</version>
         </dependency>
+
+		<!-- Añado esto para JWT
+       ************************ -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- hasta aquí para JWT
+        ************************ -->
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/natalia/relab/controller/AuthController.java
+++ b/src/main/java/com/natalia/relab/controller/AuthController.java
@@ -1,0 +1,54 @@
+package com.natalia.relab.controller;
+
+import com.natalia.relab.dto.AuthResponse;
+import com.natalia.relab.dto.LoginRequest;
+import com.natalia.relab.model.Usuario;
+import com.natalia.relab.repository.UsuarioRepository;
+import com.natalia.relab.security.JwtUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    Logger logger = LoggerFactory.getLogger(AuthController.class);
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
+
+        logger.info("Intentando login con nickname: {}", request.getNickname());
+
+        // Validar usuario + password usando findByNicknameAndPassword
+        Usuario usuario = usuarioRepository
+                .findByNicknameAndPassword(request.getNickname(), request.getPassword())
+                .orElse(null);
+
+        if (usuario == null) {
+            // Credenciales incorrectas
+            logger.info("Usuario no encontrado para ese nickname y contraseña");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // Generar JWT solo con el ID del usuario
+        String token = jwtUtil.generateToken(usuario);
+
+        // Devolver token en DTO
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+}
+
+// En este controlador, el endpoint /auth/login recibe un LoginRequest (DTO de entrada) con nickname y password,
+// valida las credenciales usando el repositorio de usuarios, y si son correctas, genera un JWT con el ID del usuario y
+// lo devuelve en un AuthResponse (DTO de salida). Si las credenciales son incorrectas, devuelve un 401 Unauthorized.

--- a/src/main/java/com/natalia/relab/controller/UsuarioController.java
+++ b/src/main/java/com/natalia/relab/controller/UsuarioController.java
@@ -1,5 +1,9 @@
 package com.natalia.relab.controller;
 
+import com.natalia.relab.dto.UsuarioMobileOutDto;
+import com.natalia.relab.model.Usuario;
+import com.natalia.relab.repository.UsuarioRepository;
+import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.natalia.relab.dto.UsuarioInDto;
@@ -11,6 +15,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -23,7 +28,36 @@ public class UsuarioController {
     @Autowired
     private UsuarioService usuarioService;
 
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private ModelMapper mapper;
+
     private static final Logger log = LoggerFactory.getLogger(UsuarioController.class); // Logger para la clase UsuarioController
+
+    // Nuevo endpoint para obtener el perfil del usuario logueado usando JWT
+    @GetMapping("/usuarios/me")
+    public ResponseEntity<UsuarioMobileOutDto> miPerfil(Authentication authentication) throws UsuarioNoEncontradoException {
+        log.info("GET /usuarios/me solicitado");
+        Long usuarioId = (Long) authentication.getPrincipal(); // Se obtiene el userId del token JWT
+
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(UsuarioNoEncontradoException::new);
+
+        UsuarioMobileOutDto dto = mapper.map(usuario, UsuarioMobileOutDto.class);
+        log.info("Perfil del usuario {} obtenido correctamente", usuarioId);
+        return ResponseEntity.ok(dto);
+    }
+
+    // Nuevo endpoint para verificar si un nickname ya existe
+    @GetMapping("/usuarios/check-nickname")
+    public ResponseEntity<Boolean> checkNickname(@RequestParam("nickname") String nickname) {
+        log.info("GET /usuarios/check-nickname?nickname={} solicitado", nickname);
+        boolean exists = usuarioRepository.existsByNickname(nickname);
+        log.info("Nickname '{}' existe: {}", nickname, exists);
+        return ResponseEntity.ok(exists);
+    }
 
     @GetMapping("/usuarios")
     public ResponseEntity<?> listarTodos(
@@ -46,13 +80,14 @@ public class UsuarioController {
         return ResponseEntity.ok(usuarios);
     }
 
-    @GetMapping("/usuarios/{id}")
-    public ResponseEntity<UsuarioOutDto> ListarPorId(@PathVariable long id) throws UsuarioNoEncontradoException {
-        log.info("GET /usuarios/{} solicitado", id);
-        UsuarioOutDto dto = usuarioService.buscarPorId(id);
-        log.info("Usuario con id {} encontrado", id);
-        return ResponseEntity.ok(dto);
-    }
+    // Este endpoint ya no lo voy a utilizar --> Lo dejo comentado
+//    @GetMapping("/usuarios/{id}")
+//    public ResponseEntity<UsuarioOutDto> ListarPorId(@PathVariable long id) throws UsuarioNoEncontradoException {
+//        log.info("GET /usuarios/{} solicitado", id);
+//        UsuarioOutDto dto = usuarioService.buscarPorId(id);
+//        log.info("Usuario con id {} encontrado", id);
+//        return ResponseEntity.ok(dto);
+//    }
 
     @PostMapping("/usuarios")
     public ResponseEntity<UsuarioOutDto> agregarUsuario(@Valid @RequestBody UsuarioInDto usuarioInDto) {
@@ -62,19 +97,85 @@ public class UsuarioController {
         return new ResponseEntity<>(nuevoUsuario, HttpStatus.CREATED);
     }
 
+    // PUT CON SEGURIDAD JWT
     @PutMapping("/usuarios/{id}")
-    public ResponseEntity<UsuarioOutDto> editarUsuario(@Valid @PathVariable long id, @RequestBody UsuarioUpdateDto usuarioUpdateDto) throws UsuarioNoEncontradoException {
-        log.info("PUT /usuarios/{} - actualización solicitada", id);
-        UsuarioOutDto nuevoUsuario = usuarioService.modificar(id, usuarioUpdateDto);
+    public ResponseEntity<UsuarioOutDto> editarUsuario(
+            @PathVariable long id,
+            @RequestBody UsuarioUpdateDto dto,
+            Authentication authentication) throws UsuarioNoEncontradoException {
+
+        log.info("PUT /usuarios/{} solicitado", id);
+        Long usuarioIdToken = (Long) authentication.getPrincipal(); // Se obtiene el userId del token JWT
+
+        if (!usuarioIdToken.equals(id)) {
+            log.warn("Usuario {} intentó actualizar el perfil de otro usuario {}", usuarioIdToken, id);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // Solo el usuario puede actualizar su propio perfil
+        }
+
+        UsuarioOutDto nuevoUsuario = usuarioService.modificar(id, dto);
         log.info("Usuario {} actualizado correctamente", id);
         return ResponseEntity.ok(nuevoUsuario);
     }
 
+
+    // PUT SIN SEGURIDAD JWT:
+//    @PutMapping("/usuarios/{id}")
+//    public ResponseEntity<UsuarioOutDto> editarUsuario(@Valid @PathVariable long id, @RequestBody UsuarioUpdateDto usuarioUpdateDto) throws UsuarioNoEncontradoException {
+//        log.info("PUT /usuarios/{} - actualización solicitada", id);
+//        UsuarioOutDto nuevoUsuario = usuarioService.modificar(id, usuarioUpdateDto);
+//        log.info("Usuario {} actualizado correctamente", id);
+//        return ResponseEntity.ok(nuevoUsuario);
+//    }
+
+
+    // Delete de un usuario con seguridad JWT
     @DeleteMapping("/usuarios/{id}")
-    public ResponseEntity<Void> eliminarUsuario(@PathVariable long id) throws UsuarioNoEncontradoException {
-        log.warn("DELETE /usuarios/{} solicitado", id); // DELETE → mejor WARN
+    public ResponseEntity<Void> eliminarUsuario(
+            @PathVariable long id,
+            Authentication authentication) throws UsuarioNoEncontradoException {
+
+        log.info("DELETE /usuarios/{} solicitado", id);
+        Long usuarioIdToken = (Long) authentication.getPrincipal(); // Se obtiene el userId del token JWT
+
+        // Seguridad: Solo el usuario puede eliminar su propio perfil
+        if (!usuarioIdToken.equals(id)) {
+            log.warn("Usuario {} intentó eliminar el perfil de otro usuario {}", usuarioIdToken, id);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         usuarioService.eliminar(id);
         log.info("Usuario {} eliminado correctamente", id);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    // DELETE SIN SEGURIDAD JWT
+//    @DeleteMapping("/usuarios/{id}")
+//    public ResponseEntity<Void> eliminarUsuario(@PathVariable long id) throws UsuarioNoEncontradoException {
+//        log.warn("DELETE /usuarios/{} solicitado", id); // DELETE → mejor WARN
+//        usuarioService.eliminar(id);
+//        log.info("Usuario {} eliminado correctamente", id);
+//        return ResponseEntity.noContent().build();
+//    }
+
+
+    // Delete de una CUENTA con seguridad JWT (o sea, eliminar usuario y datos relacionados en resto de tablas)
+    @DeleteMapping("/usuarios/{id}/cuenta")
+    public ResponseEntity<Void> eliminarCuenta(
+            @PathVariable long id,
+            Authentication authentication) throws UsuarioNoEncontradoException {
+
+        log.info("DELETE /usuarios/{}/cuenta solicitado", id);
+        Long usuarioIdToken = (Long) authentication.getPrincipal(); // Se obtiene el userId del token JWT
+
+        // Seguridad: Solo el usuario puede eliminar su propia cuenta
+        if (!usuarioIdToken.equals(id)) {
+            log.warn("Usuario {} intentó eliminar la cuenta de otro usuario {}", usuarioIdToken, id);
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        usuarioService.eliminarCuenta(id);
+        log.info("Cuenta del usuario {} eliminada correctamente", id);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/natalia/relab/dto/AuthResponse.java
+++ b/src/main/java/com/natalia/relab/dto/AuthResponse.java
@@ -1,0 +1,11 @@
+package com.natalia.relab.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthResponse {
+    private String token;
+}
+

--- a/src/main/java/com/natalia/relab/dto/LoginRequest.java
+++ b/src/main/java/com/natalia/relab/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.natalia.relab.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String nickname;
+    private String password;
+}

--- a/src/main/java/com/natalia/relab/dto/UsuarioMobileOutDto.java
+++ b/src/main/java/com/natalia/relab/dto/UsuarioMobileOutDto.java
@@ -1,0 +1,22 @@
+package com.natalia.relab.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsuarioMobileOutDto {
+
+    private long id;
+    private String nombre;
+    private String apellido;
+    private String password;
+    private String nickname;
+    private String tipoUsuario;
+    private String email;
+    private double latitud;
+    private double longitud;
+    private String direccion;
+}

--- a/src/main/java/com/natalia/relab/repository/AlquilerRepository.java
+++ b/src/main/java/com/natalia/relab/repository/AlquilerRepository.java
@@ -1,12 +1,21 @@
 package com.natalia.relab.repository;
 
 import com.natalia.relab.model.Alquiler;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 public interface AlquilerRepository extends CrudRepository<Alquiler, Long> {
     List<Alquiler> findAll();
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM alquileres a WHERE a.arrendatario.id = :usuarioId")
+    void deleteByArrendatarioId(@Param("usuarioId") Long usuarioId);
 }

--- a/src/main/java/com/natalia/relab/repository/CompraventaRepository.java
+++ b/src/main/java/com/natalia/relab/repository/CompraventaRepository.java
@@ -1,8 +1,12 @@
 package com.natalia.relab.repository;
 
 import com.natalia.relab.model.Compraventa;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +17,13 @@ public interface CompraventaRepository extends CrudRepository<Compraventa, Long>
 
     // Metodo necesario para comprobar si el producto ya está vendido:
     boolean existsByProductoId(Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM compraventas c WHERE c.comprador.id = :usuarioId")
+    void deleteByCompradorId(@Param("usuarioId") Long usuarioId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM compraventas c WHERE c.producto.id = :productoId")
+    void deleteByProductoId(@Param("productoId") Long productoId);
 }

--- a/src/main/java/com/natalia/relab/repository/ProductoRepository.java
+++ b/src/main/java/com/natalia/relab/repository/ProductoRepository.java
@@ -2,9 +2,13 @@ package com.natalia.relab.repository;
 
 import com.natalia.relab.model.Producto;
 import com.natalia.relab.model.Usuario;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +17,11 @@ import java.util.Optional;
 public interface ProductoRepository extends CrudRepository<Producto,Long> {
     List<Producto> findAll(); // Es de los metodos de la interfaz CrudRepository
     boolean existsById(@NonNull Long productoId); // Para ver si existe ese ID de ese producto antes de listar alquileres de ese producto
+    List<Producto> findByUsuarioId(Long usuarioId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM productos p WHERE p.usuario.id = :usuarioId")
+    void deleteByUsuarioId(@Param("usuarioId") Long usuarioId);
+
 }

--- a/src/main/java/com/natalia/relab/security/JwtFilter.java
+++ b/src/main/java/com/natalia/relab/security/JwtFilter.java
@@ -1,0 +1,73 @@
+package com.natalia.relab.security;
+
+
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter { // Que extienda OncePerRequestFilter hace que se ejecute una vez por cada petición HTTP
+
+    @Autowired
+    private JwtUtil jwtUtil; // Inyectamos JwtUtil para validar el token, verificar firma y extraer claims (userId)
+
+    // Este metodo se ejecuta en TODAS las peticiones antes de llegar al controller
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, // Objeto que representa la petición HTTP
+            HttpServletResponse response, // Objeto que representa la respuesta HTTP
+            FilterChain filterChain // Objeto que representa la cadena de filtros (para seguir con la ejecución de la petición)
+    ) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization"); // Se mira si la petición trae un header Authorization y si no existe es null
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) { // Si el header existe y empieza con "Bearer " (formato típico de un JWT)
+            try {
+                String token = authHeader.substring(7); // Se extrae el token quitando "Bearer " (los primeros 7 caracteres)
+                Claims claims = jwtUtil.validateToken(token); // Se valida el token usando JwtUtil, si el token no es válido (firma incorrecta o expirado) se lanza una excepción y se responde con 401 Unauthorized
+
+                Long userId = claims.get("userId", Long.class); // Si el token es válido, se extrae el userId del token (que se guardó como claim al generar el token)
+
+
+                // Se crea un objeto de autenticación de Spring Security con el userId (sin password ni roles)
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userId, null, List.of()
+                        );
+
+                // Se le dice a Spring Security que el usuario está autenticado y que la petición pertenece a ese userId
+                // Permite que en los controllers se pueda obtener el userId con @AuthenticationPrincipal Long userId
+                SecurityContextHolder.getContext()
+                        .setAuthentication(authentication);
+
+            } catch (Exception e) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+                // Si el token no es válido, se responde con 401 Unauthorized y se detiene la ejecución de la petición
+            }
+        }
+
+        filterChain.doFilter(request, response); // Continúa la petición (si el token es válido o si no hay token, se sigue con la ejecución normal, llegando al controller correspondiente)
+    }
+}
+
+// En esta clase, se intercepta cada petición HTTP que llega a mi API (antes de que se ejecute cualquier controller)
+// y se hace lo siguiente:
+//   1. Mira si la petición trae un header Authorization
+//   2. Si hay un JWT (Bearer xxx.yyy.zzz), se valida el token usando JwtUtil (firma + expiración)
+//   3. Si el token es válido, se extrae el userId del token
+//   4. Le dice a Spring Security que el usuario está autenticado y que la petición pertenece a ese userId
+//   5. Si el token no es válido, se responde con 401 Unauthorized
+
+

--- a/src/main/java/com/natalia/relab/security/JwtUtil.java
+++ b/src/main/java/com/natalia/relab/security/JwtUtil.java
@@ -38,7 +38,7 @@ public class JwtUtil {
                 .compact();
     }
 
-    // Valida un token JWT y devuelve sus claims (datos incluidos en el token)
+    // Validar un token JWT y devuelve sus claims (datos incluidos en el token)
     public Claims validateToken(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key) // Configura la clave secreta para validar la firma del token

--- a/src/main/java/com/natalia/relab/security/JwtUtil.java
+++ b/src/main/java/com/natalia/relab/security/JwtUtil.java
@@ -1,0 +1,49 @@
+package com.natalia.relab.security;
+
+
+
+import com.natalia.relab.model.Usuario;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    // Clave secreta para firmar el token
+    // (en producción se saca a application.properties)
+    // Se genera clave aleatoria al arrancar la app, por lo que los tokens no son válidos tras reiniciar la app
+    // La clave está en memoria dentro de la aplicación Java, no se expone en ningún endpoint ni se guarda en la base de datos, por lo que es segura
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+
+    // El token dura 24 horas
+    private static final long EXPIRATION_TIME = 1000 * 60 * 60 * 24;
+
+
+    // Genera un token JWT a partir de un usuario, incluyendo su nickname como subject y otros datos como claims
+    public String generateToken(Usuario usuario) {
+
+        return Jwts.builder() // La librería JJWT crea el header automáticamente aunque no lo veamos explícitamente
+                .setSubject(usuario.getNickname())
+                .claim("userId", usuario.getId()) // Un claim es un dato adicional que queremos incluir en el token
+                .claim("admin", usuario.isAdmin())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .signWith(key) // Firma el token con la clave secreta
+                .compact();
+    }
+
+    // Valida un token JWT y devuelve sus claims (datos incluidos en el token)
+    public Claims validateToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key) // Configura la clave secreta para validar la firma del token
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/natalia/relab/security/SecurityConfig.java
+++ b/src/main/java/com/natalia/relab/security/SecurityConfig.java
@@ -1,0 +1,78 @@
+package com.natalia.relab.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+    @Autowired
+    private JwtFilter jwtFilter;
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // SecurityFilterChain es una interfaz que define un filtro de seguridad para las solicitudes HTTP.
+
+        /*
+          La seguridad con JWT se aplica únicamente a las operaciones sensibles sobre usuarios.
+          El token se envía manualmente en las peticiones PUT y DELETE de usuario mediante el header Authorization.
+          El resto de recursos son públicos por simplicidad del proyecto.
+        */
+
+
+        http.csrf(csrf -> csrf.disable()) // No se usa protección CSRF porque JWT no necesita cookies ni formularios
+                .sessionManagement(sm ->
+                        sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // Spring no guarda sesión; cada request debe llevar su token
+                )
+                .authorizeHttpRequests(auth -> auth // Configuración de qué rutas son públicas y cuáles requieren autenticación
+
+                        // Para el POST de NUEVOS USUARIOS no activo seguridad
+                        .requestMatchers(HttpMethod.POST, "/usuarios").permitAll()
+
+                        // Pero abro el GET de usuarios al endpoint que controla si existe el nickname
+                        // devolverá true e false.
+                        .requestMatchers(HttpMethod.GET, "/usuarios/check-nickname").permitAll()
+
+                        /*
+                              RESTO DE USUARIOS, PUT Y DELETE están cerrados y requieren
+                              seguridad por token.  Allí la app de android trabaja con los tokens.
+                         */
+
+
+
+                        // y a continuación todos los permitidos...
+                        .requestMatchers(
+                                "/auth/**",
+                                "/ping",
+                                "/productos/**",
+                                "/reviews/**",
+                                "/servicios/**",
+                                "/alquileres/**",
+                                "/compraventas/**").permitAll()
+
+
+                        .anyRequest().authenticated() // Cualquier otra ruta no listada antes requiere autenticación
+                )
+                .addFilterBefore(jwtFilter,
+                        UsernamePasswordAuthenticationFilter.class);
+                // Se inserta mi JwtFilter antes del filtro estándar de Spring Security que maneja la autenticación por username y password.
+
+        return http.build(); // Se construye y devuelve la configuración de seguridad.
+    }
+}
+
+// En esta clase:
+// 1. Se desactiva CSRF y la sesión de Spring Security, porque no se usan cookies ni sesiones (la autenticación es con JWT)
+// 2. Se definen permisos de acceso por endpoint: todos los recursos son públicos excepto PUT y DELETE de usuarios,
+//    que requieren autenticación con JWT, es decir se define que rutas requieren token.
+// 3. Se inyecta el filtro JwtFilter para que se valide el token en cada petición antes de llegar al controller.
+//    Si el token es válido, se le dice a Spring Security que el usuario está autenticado y que la petición pertenece a
+//    ese userId. Si el token no es válido, se responde con 401 Unauthorized.  Y si no hay token, se sigue con
+//    la ejecución normal (recursos públicos).
+

--- a/src/main/java/com/natalia/relab/service/UsuarioService.java
+++ b/src/main/java/com/natalia/relab/service/UsuarioService.java
@@ -4,10 +4,12 @@ package com.natalia.relab.service;
 import com.natalia.relab.dto.UsuarioInDto;
 import com.natalia.relab.dto.UsuarioOutDto;
 import com.natalia.relab.dto.UsuarioUpdateDto;
+import com.natalia.relab.model.Producto;
 import com.natalia.relab.model.Usuario;
-import com.natalia.relab.repository.UsuarioRepository;
+import com.natalia.relab.repository.*;
 import exception.NicknameYaExisteException;
 import exception.UsuarioNoEncontradoException;
+import jakarta.transaction.Transactional;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +30,21 @@ public class UsuarioService {
 
     @Autowired                                     // Así hacemos que la capa Service pueda comunicarse con la Repository.  Crea una instancia de la clase en repository cada vez que llame a metodos de la capa service
     private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Autowired
+    private ReviewsRepository reviewsRepository;
+
+    @Autowired
+    private ServiciosRepository serviciosRepository;
+
+    @Autowired
+    private CompraventaRepository compraVentaRepository;
+
+    @Autowired
+    private AlquilerRepository alquilerRepository;
 
     // --- POST
     public UsuarioOutDto agregar(UsuarioInDto usuarioInDto) {
@@ -158,6 +175,41 @@ public class UsuarioService {
 
         usuarioRepository.delete(usuario);
         log.info("Usuario {} eliminado", id);
+    }
+
+    // --- DELETE de una CUENTA (o sea, eliminar usuario y datos relacionados en resto de tablas)
+    @Transactional
+    public void eliminarCuenta(Long usuarioId) throws UsuarioNoEncontradoException {
+
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(UsuarioNoEncontradoException::new);
+
+
+        // Reviews
+        reviewsRepository.deleteByUsuarioId(usuarioId);
+
+        // Servicios
+        serviciosRepository.deleteByUsuarioId(usuarioId);
+
+        // Compraventas donde el usuario es comprador
+        compraVentaRepository.deleteByCompradorId(usuarioId);
+
+        // Productos del usuario
+        List<Producto> productos = productoRepository.findByUsuarioId(usuarioId);
+
+        // Compraventas que referencian los productos del usuario
+        for (Producto p : productos) {
+            compraVentaRepository.deleteByProductoId(p.getId());
+        }
+
+        // Alquileres donde el usuario es arrendatario
+        alquilerRepository.deleteByArrendatarioId(usuarioId);
+
+        // Borrar productos del usuario
+        productoRepository.deleteByUsuarioId(usuarioId);
+
+        // Borrar usuario
+        usuarioRepository.delete(usuario);
     }
 
     // --- Metodo auxiliar privado para mapear y no repetir código: para volcar datos de usuario a usuarioOutDto


### PR DESCRIPTION
Esta PR implementa la infraestructura de **autenticación y autorización** basada en JWT en la API, incluyendo:

- Dependencias y utilidad para JWT
- Login que emite tokens
- Filtro para validar tokens en cada petición
- Configuración de Spring Security para rutas públicas y protegidas.
- Adaptación de UsuarioController para usar el userId del token en operaciones sensibles.

El objetivo es **hacer la API segura y stateless para que las operaciones de usuario solo puedan realizarse por el propio usuario autenticado**

## Cambios por commit
### COMMIT 1 - Dependencias de seguridad (base)

- pom.xml actualizado con `spring-boot-starter-security`, `jjwt-api`, `jjwt-impl`, `jjwt-jackson`
- Preparación del proyecto para JWT sin cambiar comportamiento o agregando nuevas funcionalidades

### COMMIT 2 - Utilidad JWT (`JwtUtil`)

- Clase `JwtUtil` que genera y valida tokens JWT
- Incluye: Claims, Fecha de Expiración y firma con Clave secreta.

### COMMIT 3 -  Login y emisión de token (`AuthController`)

- Endpoint `/auth/login` que devuelve JWT
- DTO `AuthResponse` para enviar token

### COMMIT 4 -  Filtro JWT (`JwtFilter`)

- Filtro que intercepta cada petición HTTP y valida el token
- Rellena `SecurityContextHolder` con `Authentication` (userId)

### COMMIT 5 -  Configuración de seguridad (`SecurityConfig`)
Configuración de Spring Security:

- CSRF deshabilitado
- Sesión STATELESS
- Rutas públicas (permitAll) y protegidas (authenticated)
- Inserta JwtFilter antes de UsernamePasswordAuthenticationFilter (filtrado propio de Spring Security)

### COMMIT 6 -  Adaptar `UsuarioController` a JWT
Nuevos endpoints y modificaciones:

- `/usuarios/me` → devuelve usuario logueado
- `PUT /usuarios/{id}` → solo usuario autenticado puede modificar
- `DELETE /usuarios/{id}` y `/usuarios/{id}/cuenta` → solo usuario autenticado puede eliminar

Closes #97 