### PR TITLE
nuevo método para PUT de campo activo

### DIFF
--- a/src/main/java/com/natalia/relab/controller/ProductoController.java
+++ b/src/main/java/com/natalia/relab/controller/ProductoController.java
@@ -2,6 +2,7 @@ package com.natalia.relab.controller;
 
 import com.natalia.relab.dto.ProductoInDto;
 import com.natalia.relab.dto.ProductoOutDto;
+import com.natalia.relab.dto.ProductoUpdateActivoDto;
 import com.natalia.relab.dto.ProductoUpdateDto;
 import com.natalia.relab.model.Producto;
 import com.natalia.relab.service.ProductoService;
@@ -91,6 +92,18 @@ public class ProductoController {
 //        ProductoOutDto actualizado = productoService.modificar(id, productoUpdateDto);
 //        return ResponseEntity.ok(actualizado);
 //    }
+
+
+    // PUT para actualizar solo el campo activo de productos.
+    // Necesario para cambiar solo el valor de ese campo sin tener que volver a actualizar
+    // todos los campos del registro.
+    @PutMapping("/productos/{id}/activo")
+    public ResponseEntity<Void> actualizarActivo(@PathVariable Long id, @RequestBody ProductoUpdateActivoDto dto) throws ProductoNoEncontradoException {
+        log.info("PUT /productos/{}/activo - actualización de estado activo a {}", id, dto.isActivo());
+        productoService.actualizarActivo(id, dto.isActivo());
+        log.info("PUT /productos/{}/activo - estado actualizado correctamente", id);
+        return ResponseEntity.noContent().build();
+    }
 
     // Versión que PERMITE ACTUALIZACIÓN DE IMÁGENES
     @PutMapping("/productos/{id}")

--- a/src/main/java/com/natalia/relab/dto/ProductoUpdateActivoDto.java
+++ b/src/main/java/com/natalia/relab/dto/ProductoUpdateActivoDto.java
@@ -1,0 +1,13 @@
+package com.natalia.relab.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductoUpdateActivoDto {
+    private boolean activo;
+}

--- a/src/main/java/com/natalia/relab/service/ProductoService.java
+++ b/src/main/java/com/natalia/relab/service/ProductoService.java
@@ -254,6 +254,20 @@ public class ProductoService {
         return mapToOutDto(actualizado);
     }
 
+    // PUT para actualizar solo el campo Activo (Se llamará desde compras y alquileres en App Android
+    public void actualizarActivo(Long id, boolean activo) throws ProductoNoEncontradoException{
+        log.info("Servicio: actualizando producto {}", id);
+        Producto producto = productoRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.warn("Producto {} no encontrado al intentar actualizar estado activo", id);
+                    return new ProductoNoEncontradoException();
+                });
+        producto.setActivo(activo);
+        productoRepository.save(producto);
+        log.info("Producto {} actualizado correctamente. Nuevo estado activo: {}", id, activo);
+    }
+
+
 
     // --- DELETE
     public void eliminar(long id) throws ProductoNoEncontradoException {


### PR DESCRIPTION
Nuevo método PUT necesario en mi aplicación Android para que tras acciones de compraventa o alquiler, los productos pasen de activos a inactivos.  He añadido operación en `ProductoController`, un nuevo DTO (`ProductoUpdateActivoDto`) y nuevo método en `ProductoService`.

#### Motivo por el que he optado por PUT y no por PATCH:
Uso PUT porque no estoy parcheando el recurso completo, sino actualizando un subrecurso (`/activo`) que representa una operación de dominio idempotente. PATCH tendría sentido para modificaciones parciales genéricas, pero aquí quiero una **acción explícita, segura y con intención clara**.